### PR TITLE
Add a forget button, which detach the instance from demoinstance

### DIFF
--- a/backend/demoinstance/demo.py
+++ b/backend/demoinstance/demo.py
@@ -324,6 +324,10 @@ class Demo():
         else:
             return False
 
+    def detach_instance(self, instance):
+        self.database_insert_server(instance, status='DELETED')
+        
+        
     def check_user_own_instance_type(self, token, image_key):
         query = self.database.query(Instance).filter(
             Instance.image_key == image_key,

--- a/backend/demoinstance/http.py
+++ b/backend/demoinstance/http.py
@@ -55,6 +55,10 @@ class Handler(BaseHTTPRequestHandler, object):
         f.close()
         return
 
+    def detach_instance(self, instance):
+        self.demo.detach_instance(instance)
+        self.send_http_message()
+    
     def instance_create(self, image_key, time=None):
         id = self.demo.create_instance(
             image_key,
@@ -244,6 +248,14 @@ class Handler(BaseHTTPRequestHandler, object):
                 self.instance_info(match.group(1))
                 return
 
+            match = re.match("/api/forget/instance/(.*)", self.path)
+            if match:
+                if not self.demo.auth.is_admin(self.user.login):
+                    self.send_http_error(404, 'No action')
+                    return
+                self.detach_instance(match.group(1))
+                return
+            
             match = re.match("/api/image/(.*)", self.path)
             if match:
                 self.image_info(match.group(1))

--- a/frontend/js/controller/admin.js
+++ b/frontend/js/controller/admin.js
@@ -71,6 +71,14 @@ demoApp.controller('adminController', function($scope, $http, $location, instanc
         );
     };
 
+    $scope.forgetInstance = function(id) {
+        instanceService.forgetInstance(
+            id,
+            $scope.refresh,
+            errorCallback
+        );
+    };
+    
     $scope.addTimeInstance = function(instance) {
         instanceService.setTimeInstance(
             instance.id,

--- a/frontend/js/service/instanceService.js
+++ b/frontend/js/service/instanceService.js
@@ -9,6 +9,14 @@ demoApp.factory('instanceService', function($http, $location) {
         success(success).
         error(fail);
     };
+
+    var forgetInstance = function(id, success, fail) {
+        if (typeof(success)==='undefined') success = empty;
+        if (typeof(fail)==='undefined') fail = empty;
+        $http.get('/api/forget/instance/'+ id).
+        success(success).
+        error(fail);
+    };
     
     var addTimeInstance = function(id, time, success, fail) {
         if (typeof(success)==='undefined') success = empty;
@@ -37,6 +45,7 @@ demoApp.factory('instanceService', function($http, $location) {
     return {
         deleteInstance : deleteInstance,
         addTimeInstance : addTimeInstance,
-        setTimeInstance : setTimeInstance
+        setTimeInstance : setTimeInstance,
+	forgetInstance : forgetInstance
     };
 });

--- a/frontend/pages/admin.html
+++ b/frontend/pages/admin.html
@@ -73,6 +73,7 @@
                 <td data-title="'action'">
                     <span ng-show="instance.status != 'DELETED'" ng-click="setInstance(instance)" data-toggle="modal" data-target="#modalDestroy" class="glyphicon glyphicon-remove"></span>
                     <span ng-show="instance.status != 'DELETED'" ng-click="go_to_instance(instance)" class="glyphicon glyphicon glyphicon-eye-open"></span>
+		    <span ng-show="instance.status != 'DELETED'" ng-click="setInstance(instance)" data-toggle="modal" data-target="#modalForget" class="glyphicon glyphicon glyphicon-log-out"></span>
                 </td>
             </tr>
         </tbody>
@@ -135,6 +136,24 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">{{ 'CANCEL' | translate }}</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="deleteInstance(instance.id);">{{ 'SUBMIT' | translate }}</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="in modal fade" id="modalForget" tabindex="-1" role="dialog" aria-labelledby="myForgetModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="myForgetModalLabel">{{ 'FORGET' | translate }}</h4>
+                </div>
+                <div class="modal-body">
+                {{ 'FORGETTING_INSTANCE'|translate }}.
+                {{ 'ARE_YOU_SURE' | translate}}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">{{ 'CANCEL' | translate }}</button>
+                    <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="forgetInstance(instance.id);">{{ 'SUBMIT' | translate }}</button>
                 </div>
             </div>
         </div>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -91,6 +91,7 @@
             NEW_INSTANCE: 'Instances',
             CREATING_INSTANCE: 'Creating instance',
             DESTROYING_INSTANCE: 'Your instance will be permanently destroyed',
+            FORGETTING_INSTANCE: 'Your instance will be detached and will not be destroyed automatically',
             STARTING_INSTANCE: 'Starting instance',
             STARTING_SYSTEM: 'Starting system',
             CREATE_INSTANCE_OF: 'Create instance of ',
@@ -107,6 +108,7 @@
             SUBMIT: 'Submit',
             CANCEL: 'Cancel',
             DESTROY: 'Destroy instance',
+            FORGET: 'Forgetting instance',
 
             LOGIN:'Please log in',
             DISCONNECT: 'disconnect',
@@ -134,6 +136,7 @@
             NEW_INSTANCE: 'Instances',
             CREATING_INSTANCE: 'Cr&eacute;ation de votre environnement de d&eacute;monstration',
             DESTROYING_INSTANCE: 'Votre instance sera détruite pour toujours',
+            FORGETTING_INSTANCE: 'Votre instance sera détachée et ne sera pas supprimée automatiquement',
             STARTING_INSTANCE: 'D&eacute;marrage de votre environnement de d&eacute;monstration',
             STARTING_SYSTEM: 'Configuration de votre environnement de d&eacute;monstration',
             CREATE_INSTANCE_OF: 'Cr&eacute;ation de l\'instance ',
@@ -150,6 +153,7 @@
             SUBMIT: 'Valider',
             CANCEL: 'Annuler',
             DESTROY: 'Détruire l\'instance',
+            FORGET: 'Détacher l\'instance',
 
             LOGIN:'Connectez vous',
             DISCONNECT: 'Déconnection',


### PR DESCRIPTION
Add a forget button, which detach the instance from demoinstance without deleting it
## Before
![demo-forget-before](https://cloud.githubusercontent.com/assets/2150524/20174301/8337c6e8-a73d-11e6-9b3b-31869854439c.png)

## After
![demo-forget-after](https://cloud.githubusercontent.com/assets/2150524/20174309/8caeafde-a73d-11e6-9276-4356f2e433c2.png)
![demo-forget-after2](https://cloud.githubusercontent.com/assets/2150524/20174315/91d4cb7e-a73d-11e6-87e8-f651803d371a.png)



cf #19