### PR TITLE
feat(openstack): support Keystone v3 domains in OpenStack provider

### DIFF
--- a/backend/demoinstance/provider/prov_openstack.py
+++ b/backend/demoinstance/provider/prov_openstack.py
@@ -13,11 +13,21 @@ class Openstack(DemoProv):
             self.region = config['region']
         else:
             self.region = None
+        if 'user_domain' in config:
+            user_domain = config['user_domain']
+        else:
+            user_domain = 'Default'
+        if 'project_domain' in config:
+            project_domain = config['project_domain']
+        else:
+            project_domain = 'Default'
 
         self.nova = Client(
             2, self.user, self.password,
             self.tenant, self.url,
-            region_name=self.region
+            region_name=self.region,
+            user_domain_name=user_domain,
+            project_domain_name=project_domain
         )
 
     def get_instances(self):


### PR DESCRIPTION
Read optional `user_domain` and `project_domain` from the [PROV_OPENSTACK] section and forward them to novaclient's Client() as `user_domain_name` / `project_domain_name`.

Both default to 'Default' when not set, keeping the existing behaviour for legacy Keystone v2.0 deployments. This unlocks authentication against OpenStack 2025.2 (Keystone v3 only), which otherwise returns:

    400 Expecting to find domain in user.